### PR TITLE
feat(db): добавить поддержку MongoDB и Prisma с docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ yarn-error.log*
 next-env.d.ts
 
 .idea
+
+/app/generated/prisma

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  mongo:
+    image: mongo:6.0
+    container_name: mongo_db
+    restart: unless-stopped
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGODB_ADMIN_USERNAME}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGODB_ADMIN_PASSWORD}
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+
+  mongo-express:
+    image: mongo-express:1.0
+    container_name: mongo_express
+    restart: unless-stopped
+    depends_on:
+      - mongo
+    environment:
+      ME_CONFIG_MONGODB_ADMINUSERNAME: ${MONGODB_ADMIN_USERNAME}
+      ME_CONFIG_MONGODB_ADMINPASSWORD: ${MONGODB_ADMIN_PASSWORD}
+      ME_CONFIG_MONGODB_SERVER: mongo
+      ME_CONFIG_BASICAUTH_USERNAME: ${MONGODB_USERNAME}
+      ME_CONFIG_BASICAUTH_PASSWORD: ${MONGODB_PASSWORD}
+    ports:
+      - "8081:8081"
+
+volumes:
+  mongo_data:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "chat-web-app",
       "version": "0.1.0",
       "dependencies": {
+        "@prisma/client": "^6.10.1",
         "@tailwindcss/forms": "^0.5.10",
         "clsx": "^2.1.1",
         "next": "15.3.3",
@@ -24,6 +25,7 @@
         "@types/react-dom": "^19",
         "eslint": "^8.57.1",
         "eslint-config-next": "^15.3.3",
+        "prisma": "^6.10.1",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -867,6 +869,88 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.10.1.tgz",
+      "integrity": "sha512-Re4pMlcUsQsUTAYMK7EJ4Bw2kg3WfZAAlr8GjORJaK4VOP6LxRQUQ1TuLnxcF42XqGkWQ36q5CQF1yVadANQ6w==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/config": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.10.1.tgz",
+      "integrity": "sha512-kz4/bnqrOrzWo8KzYguN0cden4CzLJJ+2VSpKtF8utHS3l1JS0Lhv6BLwpOX6X9yNreTbZQZwewb+/BMPDCIYQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jiti": "2.4.2"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.10.1.tgz",
+      "integrity": "sha512-k2YT53cWxv9OLjW4zSYTZ6Z7j0gPfCzcr2Mj99qsuvlxr8WAKSZ2NcSR0zLf/mP4oxnYG842IMj3utTgcd7CaA==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.10.1.tgz",
+      "integrity": "sha512-Q07P5rS2iPwk2IQr/rUQJ42tHjpPyFcbiH7PXZlV81Ryr9NYIgdxcUrwgVOWVm5T7ap02C0dNd1dpnNcSWig8A==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.10.1",
+        "@prisma/engines-version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
+        "@prisma/fetch-engine": "6.10.1",
+        "@prisma/get-platform": "6.10.1"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c.tgz",
+      "integrity": "sha512-ZJFTsEqapiTYVzXya6TUKYDFnSWCNegfUiG5ik9fleQva5Sk3DNyyUi7X1+0ZxWFHwHDr6BZV5Vm+iwP+LlciA==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.10.1.tgz",
+      "integrity": "sha512-clmbG/Jgmrc/n6Y77QcBmAUlq9LrwI9Dbgy4pq5jeEARBpRCWJDJ7PWW1P8p0LfFU0i5fsyO7FqRzRB8mkdS4g==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.10.1",
+        "@prisma/engines-version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
+        "@prisma/get-platform": "6.10.1"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.10.1.tgz",
+      "integrity": "sha512-4CY5ndKylcsce9Mv+VWp5obbR2/86SHOLVV053pwIkhVtT9C9A83yqiqI/5kJM9T1v1u1qco/bYjDKycmei9HA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.10.1"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -4179,7 +4263,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -5136,6 +5220,32 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prisma": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.10.1.tgz",
+      "integrity": "sha512-khhlC/G49E4+uyA3T3H5PRBut486HD2bDqE2+rvkU0pwk9IAqGFacLFUyIx9Uw+W2eCtf6XGwsp+/strUwMNPw==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "6.10.1",
+        "@prisma/engines": "6.10.1"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/prop-types": {
@@ -6120,7 +6230,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@prisma/client": "^6.10.1",
     "@tailwindcss/forms": "^0.5.10",
     "clsx": "^2.1.1",
     "next": "15.3.3",
@@ -25,6 +26,7 @@
     "@types/react-dom": "^19",
     "eslint": "^8.57.1",
     "eslint-config-next": "^15.3.3",
+    "prisma": "^6.10.1",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,82 @@
+generator client {
+  provider = "prisma-client-js"
+  output   = "../app/generated/prisma"
+}
+
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id             String    @id @default(auto()) @map("_id") @db.ObjectId
+  name           String?
+  email          String?   @unique
+  emailVerified  DateTime?
+  image          String?
+  hashedPassword String?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  conversationIds String[]       @db.ObjectId
+  conversations   Conversation[] @relation(fields: [conversationIds], references: [id])
+
+  seenMessageIds String[]  @db.ObjectId
+  seenMessages   Message[] @relation("Seen", fields: [seenMessageIds], references: [id])
+
+  accounts Account[]
+  messages Message[]
+}
+
+model Account {
+  id                String   @id @default(auto()) @map("_id") @db.ObjectId
+  userId            String   @db.ObjectId
+  type              String
+  provider          String
+  providerAccountId String
+  refresh_token     String?  @db.String
+  access_token      String?  @db.String
+  expires_at        Int?
+  token_type        String?
+  scope             String?
+  id_token          String?  @db.String
+  session_state     String?
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
+}
+
+model Conversation {
+  id            String   @id @default(auto()) @map("_id") @db.ObjectId
+  lastMessageAt DateTime @default(now())
+  name          String?
+  isGroup       Boolean?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  messagesIds String[]  @db.ObjectId
+  messages    Message[]
+
+  userIds String[] @db.ObjectId
+  users   User[]   @relation(fields: [userIds], references: [id])
+}
+
+model Message {
+  id        String   @id @default(auto()) @map("_id") @db.ObjectId
+  body      String?
+  image     String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  seenIds String[] @db.ObjectId
+  seen    User[]   @relation("Seen", fields: [seenIds], references: [id])
+
+  conversationId String?       @db.ObjectId
+  Conversation   Conversation? @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+
+  senderId String? @db.ObjectId
+  sender   User?   @relation(fields: [senderId], references: [id], onDelete: Cascade)
+}

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,5 @@
+DATABASE_URL="mongodb://admin:secret123@localhost:27017/messenger?authSource=admin"
+MONGODB_ADMIN_USERNAME=admin
+MONGODB_ADMIN_PASSWORD=secret123
+MONGODB_USERNAME=admin
+MONGODB_PASSWORD=secret123


### PR DESCRIPTION
### Что сделано

- Добавлен docker-compose с сервисами:
  - MongoDB с настройкой администратора через переменные окружения.
  - mongo-express для удобного веб-администрирования базы.
- Создан .sample.env с примером переменных окружения для MongoDB.
- Добавлена Prisma схема с моделями User, Account, Conversation и Message, настроенная под MongoDB.
- Обновлены зависимости проекта: добавлены `prisma` и `@prisma/client`.

### Почему

- Обеспечить локальную среду для разработки с MongoDB и удобным веб-интерфейсом.
- Использовать Prisma для удобной работы с базой данных и типизацией.
- Подготовить основу для дальнейшей реализации бизнес-логики с MongoDB.

### Как проверить

1. Запустить `docker-compose up -d`.
2. Убедиться, что сервисы `mongo` и `mongo-express` запущены и доступны (mongo-express — по порту 8081).
3. Проверить подключение к базе из приложения с помощью переменных из `.env`.
4. Сгенерировать Prisma клиент и проверить корректность моделей.

### Что планируется

- Интеграция Prisma в бэкенд-логику.
- Настройка миграций и seed-скриптов.
- Реализация API для работы с пользователями и сообщениями.
